### PR TITLE
More instructions for pcre on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ The easiest way to do that is with [Homebrew](https://brew.sh/):
 ```
 brew install pcre
 ```
+If that doesn't help, try running `brew doctor` and fix
+the issues it finds.
 
 ## Quickstart
 To compile and run the binary:


### PR DESCRIPTION
Summary:
Turns out that `brew` can succeed installing `pcre`, but still
not install development headers in `/usr/local/include/`
if that path is not writable. `brew doctor` should find that
and related problems.

Relevant ticket: #8

Reviewed By: patapizza, JonCoens

Differential Revision: D5031503

fbshipit-source-id: ba0b8e8